### PR TITLE
Update insert_rows() (and _cols()) to two-argument signatures

### DIFF
--- a/src/fastGrplars.cpp
+++ b/src/fastGrplars.cpp
@@ -250,7 +250,7 @@ uvec fastGrplars(const mat& x, const vec& y, const uword& sMax,
         	}
 			// update correlations (adjustment for unequal group size is taken
         	// care of by update formula)
-			r.insert_rows(k, 1, false);	// do not initialize new memory
+			r.insert_rows(k, 1);	// do not initialize new memory
 			r(k) = (r(k-1) - gamma * a) / sigma;
  			corY.shed_row(whichMin);
 			corU.shed_row(whichMin);
@@ -265,7 +265,7 @@ uvec fastGrplars(const mat& x, const vec& y, const uword& sMax,
 			}
         }
         // update active set
-		active.insert_rows(k, 1, false);	// do not initialize new memory
+		active.insert_rows(k, 1);	// do not initialize new memory
 		active(k) = inactive(whichMin);
 		// update inactive set
 		inactive.shed_row(whichMin);

--- a/src/fastLars.cpp
+++ b/src/fastLars.cpp
@@ -171,7 +171,7 @@ uvec fastLars(const mat& x, const vec& y, const uword& sMax,
         double minGammaMinus, minGammaPlus, gamma;
         minGammaMinus = gammaMinus.min(whichMinus);
         minGammaPlus = gammaPlus.min(whichPlus);
-		signs.insert_rows(k, 1, false);	// do not initialize new memory
+		signs.insert_rows(k, 1);	// do not initialize new memory
         if(minGammaMinus < minGammaPlus) {
         	whichMin = whichMinus;
         	gamma = minGammaMinus;
@@ -182,13 +182,13 @@ uvec fastLars(const mat& x, const vec& y, const uword& sMax,
         	signs(k) = -1;
         }
         // update correlations
-		r.insert_rows(k, 1, false);			// do not initialize new memory
+		r.insert_rows(k, 1);			// do not initialize new memory
         r(k) = r(k-1) - gamma * a;
 		corY.shed_row(whichMin);
 		corU.shed_row(whichMin);
 		corY = corY - gamma * corU;
 		// update active set
-		active.insert_rows(k, 1, false);	// do not initialize new memory
+		active.insert_rows(k, 1);	// do not initialize new memory
 		active(k) = inactive(whichMin);
 		// update inactive set
 		inactive.shed_row(whichMin);

--- a/src/fastLasso.cpp
+++ b/src/fastLasso.cpp
@@ -286,8 +286,8 @@ void fastLasso(const mat& x, const vec& y, const double& lambda,
   						// correct way
   						// insert row and column without initializing memory
   						// (set_size() and reshape() have strange behavior)
-  						L.insert_rows(k, 1, false);
-  						L.insert_cols(k, 1, false);
+  						L.insert_rows(k, 1);
+  						L.insert_cols(k, 1);
   						// fill new parts of the matrix
   						for(uword j = 0; j < k; j++) {
   							L(k, j) = l(j);
@@ -300,7 +300,7 @@ void fastLasso(const mat& x, const vec& y, const double& lambda,
   				// in case of singularity
   				if(rank == k) {
   					// singularity: drop variable for good
-  					ignores.insert_rows(s, 1, false);	// do not initialize new memory
+  					ignores.insert_rows(s, 1);	// do not initialize new memory
   					ignores(s) = newJ;
   					s++;	// increase number of ignored variables
   					p--;	// decrease number of variables
@@ -310,10 +310,10 @@ void fastLasso(const mat& x, const vec& y, const double& lambda,
   					}
   				} else {
   					// no singularity: add variable to active set
-  					active.insert_rows(k, 1, false);	// do not initialize new memory
+  					active.insert_rows(k, 1);	// do not initialize new memory
   					active(k) = newJ;
   					// keep track of sign of correlation for new active variable
-  					signs.insert_rows(k, 1, false);		// do not initialize new memory
+  					signs.insert_rows(k, 1);		// do not initialize new memory
   					signs(k) = sign(corY(newJ));
   					k++;	// increase number of active variables
   				}
@@ -436,7 +436,7 @@ void fastLasso(const mat& x, const vec& y, const double& lambda,
   			L = symmatu(L);
   			// add dropped variables to inactive set and make sure
   			// coefficients are 0
-  			inactive.insert_rows(m, drops.n_elem, false);
+  			inactive.insert_rows(m, drops.n_elem);
   			for(uword j = 0; j < drops.n_elem; j++) {
   				uword newInactive = active(drops(j));
   				inactive(m + j) = newInactive;
@@ -529,7 +529,7 @@ SEXP R_fastLasso(SEXP R_x, SEXP R_y, SEXP R_lambda, SEXP R_useSubset,
       useGram, false, intercept, coefficients, residuals, crit);
 	if(useIntercept) {
 		// prepend intercept
-		coefficients.insert_rows(0, 1, false);
+		coefficients.insert_rows(0, 1);
 		coefficients(0) = intercept;
 	}
 	return List::create(

--- a/src/fastSparseLTS.cpp
+++ b/src/fastSparseLTS.cpp
@@ -140,7 +140,7 @@ SEXP R_testLasso(SEXP R_x, SEXP R_y, SEXP R_lambda, SEXP R_initial,
 	vec coefficients = subset.coefficients;
 	if(useIntercept) {
 		// prepend intercept
-		coefficients.insert_rows(0, 1, false);
+		coefficients.insert_rows(0, 1);
 		coefficients(0) = subset.intercept;
 	}
 	return List::create(
@@ -196,7 +196,7 @@ SEXP R_testCStep(SEXP R_x, SEXP R_y, SEXP R_lambda, SEXP R_subset,
 	vec coefficients = subset.coefficients;
 	if(useIntercept) {
 		// prepend intercept
-		coefficients.insert_rows(0, 1, false);
+		coefficients.insert_rows(0, 1);
 		coefficients(0) = subset.intercept;
 	}
 	return List::create(
@@ -422,7 +422,7 @@ SEXP R_fastSparseLTS(SEXP R_x, SEXP R_y, SEXP R_lambda, SEXP R_initial,
 	vec coefficients = best.coefficients;
 	if(useIntercept) {
 		// prepend intercept
-		coefficients.insert_rows(0, 1, false);
+		coefficients.insert_rows(0, 1);
 		coefficients(0) = best.intercept;
 	}
 	return List::create(


### PR DESCRIPTION
When updating RcppArmadillo to no longer suppress deprecation warning, initially for the value setting use described and changed in detail in [RcppCore/RcppArmadillo#391](https://github.com/RcppCore/RcppArmadillo/issues/391), we found one statement in your package also triggering a number of warnings such as

        fastGrplars.cpp:253:38: warning: ‘void arma::Col<eT>::insert_rows(arma::uword, arma::uword, bool) 
           [with eT = double; arma::uword = unsigned int]’ is deprecated [-Wdeprecated-declarations]

This PR addresses them.  Armadillo no longers off a variant with a boolean, and seemingly always initializes (so some
of your code comments no longer match).

The package passes its tests as before.

It would be much appreciated if you could apply this pull request and update the package at CRAN within the next few months. Let me know if you have any questions.