### PR TITLE
Remove calls to Rcpp::LdFlags() from src/Makevars*

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,2 @@
-## Use the R_HOME indirection to support installations of multiple R version
-#PKG_LIBS = `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"` $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
-PKG_LIBS = `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"` $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS)
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,2 @@
-## This assume that we can call Rscript to ask Rcpp about its locations
-## Use the R_HOME indirection to support installations of multiple R version
-#PKG_LIBS = $(shell $(R_HOME)/bin/Rscript.exe -e "Rcpp:::LdFlags()") $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
-PKG_LIBS = $(shell $(R_HOME)/bin/Rscript.exe -e "Rcpp:::LdFlags()") $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS)
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS)


### PR DESCRIPTION
This is another small thing we are going to start messaging about in the next Rcpp release: calls for linker (or include) flags have not been needed with for many many years but stuck around in some packages created before the change. 
So with the next Rcpp (i.e. the version from its repo) robustHD shows

```
'LdFlags' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.
'RcppLdFlags' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.
```

That will eventually (in a year?) become a warning and then an error.  So there is no hurry, but the next time you update the package the change should probably be part of it too.   Now `src/Makevars*` look like the reference version in RcppArmadillo.
